### PR TITLE
Write version to uninstall entry on Windows

### DIFF
--- a/windows-setup/xournalpp.nsi
+++ b/windows-setup/xournalpp.nsi
@@ -267,6 +267,7 @@ Section "Xournal++" SecXournalpp
 	; Add uninstall entry. See https://docs.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
 	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "DisplayIcon" '"$INSTDIR\bin\xournalpp.exe"'
 	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "DisplayName" "Xournal++"
+	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "DisplayVersion" "${XOURNALPP_VERSION}"
 	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "Publisher" "The Xournal++ Team"
 	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "URLInfoAbout" "https://xournalpp.github.io"
 	WriteRegStr SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\Xournal++" "InstallLocation" '"$INSTDIR"'


### PR DESCRIPTION
*Only line 270 is related to this PR. It seems that there is a line ending issue with this file.* 🤔

This PR allows the Windows installer to write the program version to the uninstall registry entry, so [WinGet](https://github.com/microsoft/winget-cli) will be able to recognize the installed version of Xournal++.
![image](https://user-images.githubusercontent.com/56779163/210139015-8468351c-94ce-416a-a0fa-b3ac8708b309.png)
